### PR TITLE
Add logLevel option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ This changelog also contains important changes in dependencies.
 ### Added
 
 - feat: update typescript types definition
+- feat: add logLevel option
 
 ### Changed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ svgtypes = "0.8.0"
 tiny-skia = "0.6.1"
 fontdb = "0.7.0"
 log = "0.4.11"
+env_logger = "0.9.0"
 serde = { version = "1", features = ["derive"] }
 
 [target.'cfg(all(any(windows, unix), target_arch = "x86_64", not(target_env = "musl")))'.dependencies]

--- a/index.d.ts
+++ b/index.d.ts
@@ -38,6 +38,7 @@ export type ResvgRenderOptions = {
     right?: number
     bottom?: number
   }
+  logLevel?: 'off' | 'error' | 'warn' | 'info' | 'debug' | 'trace'
 }
 
 export function render(svg: string, options?: ResvgRenderOptions): Buffer

--- a/src/fonts.rs
+++ b/src/fonts.rs
@@ -4,6 +4,7 @@
 
 use crate::options::*;
 use usvg::fontdb::Database;
+use log::{warn, debug, error};
 
 /// Loads fonts.
 pub fn load_fonts(font_options: &JsFontOptions) -> Database {
@@ -20,7 +21,7 @@ pub fn load_fonts(font_options: &JsFontOptions) -> Database {
   // 加载指定路径的字体
   for path in &font_options.font_files {
     if let Err(e) = fontdb.load_font_file(path) {
-      log::warn!("Failed to load '{}' cause {}.", path, e);
+      warn!("Failed to load '{}' cause {}.", path, e);
     }
   }
 
@@ -40,7 +41,7 @@ pub fn load_fonts(font_options: &JsFontOptions) -> Database {
   fontdb.set_cursive_family(&font_options.cursive_family);
   fontdb.set_fantasy_family(&font_options.fantasy_family);
   fontdb.set_monospace_family(&font_options.monospace_family);
-  println!(
+  debug!(
     "Loaded {} font faces in {}ms.",
     fontdb.len(),
     now.elapsed().as_millis()
@@ -59,7 +60,7 @@ pub fn load_fonts(font_options: &JsFontOptions) -> Database {
     Some(id) => {
       let (src, index) = fontdb.face_source(id).unwrap();
       if let fontdb::Source::File(ref path) = &src {
-        println!(
+        debug!(
           "Font '{}':{} found in {}ms.",
           path.display(),
           index,
@@ -68,8 +69,7 @@ pub fn load_fonts(font_options: &JsFontOptions) -> Database {
       }
     }
     None => {
-      // log::warn!("Error: The default font '{}' not found.", font_family);
-      eprintln!("Error: The default font '{}' not found.", font_family);
+      error!("Error: The default font '{}' not found.", font_family);
     }
   }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,8 @@ fn render(ctx: napi::CallContext) -> napi::Result<napi::JsBuffer> {
     options::JsOptions::default()
   };
 
+  let _ = env_logger::builder().filter_level(js_options.log_level).try_init();
+
   // Parse the background
   let background =
     parse_color(&js_options.background).map_err(|e| napi::Error::from_reason(format!("{}", e)))?;

--- a/src/options.rs
+++ b/src/options.rs
@@ -25,6 +25,20 @@ enum FitToDef {
   Zoom(f32),
 }
 
+#[derive(Deserialize)]
+#[serde(
+  rename_all = "lowercase",
+  remote = "log::LevelFilter"
+)]
+enum LogLevelDef {
+  Off,
+  Error,
+  Warn,
+  Info,
+  Debug,
+  Trace,
+}
+
 /// The javascript options passed to `render()`.
 #[derive(Deserialize)]
 #[serde(rename_all = "camelCase", default, deny_unknown_fields)]
@@ -85,6 +99,9 @@ pub struct JsOptions {
 
   /// Crop options
   pub crop: JsCropOptions,
+
+  #[serde(with = "LogLevelDef")]
+  pub log_level: log::LevelFilter,
 }
 
 impl Default for JsOptions {
@@ -99,6 +116,7 @@ impl Default for JsOptions {
       fit_to: usvg::FitTo::Original,
       background: None,
       crop: JsCropOptions::default(),
+      log_level: log::LevelFilter::Error
     }
   }
 }


### PR DESCRIPTION
This PR adds a `logLevel` option to handle the granularity of the log messages. 

Fix #10