### PR TITLE
fix: Potential memory leak issues in node

### DIFF
--- a/js-binding.d.ts
+++ b/js-binding.d.ts
@@ -39,6 +39,7 @@ export class Resvg {
   get width(): number
   /** Get the SVG height */
   get height(): number
+  free(): void
 }
 export class RenderedImage {
   /** Write the image data to Buffer */
@@ -49,4 +50,5 @@ export class RenderedImage {
   get width(): number
   /** Get the PNG height */
   get height(): number
+  free(): void
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,6 +131,12 @@ impl RenderedImage {
     pub fn height(&self) -> u32 {
         self.pix.height()
     }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[napi]
+    pub fn free(&mut self) {
+        self.pix = Pixmap::new(1,1).expect("Failed to create empty Pixmap");
+    }
 }
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -267,6 +273,21 @@ impl Resvg {
     #[napi(getter)]
     pub fn height(&self) -> f32 {
         self.tree.size.height().round()
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[napi]
+    pub fn free(&mut self) {
+        self.tree = usvg::Tree {
+            size: usvg::Size::from_wh(1.0, 1.0).unwrap(),
+            view_box: usvg::ViewBox {
+                rect: usvg::NonZeroRect::from_ltrb(0.0, 0.0, 1.0, 1.0).unwrap(),
+                aspect: usvg::AspectRatio::default(),
+            },
+            root: usvg::Node::new(usvg::NodeKind::Group(usvg::Group::default()))
+        };
+
+        self.js_options = JsOptions::default();
     }
 }
 


### PR DESCRIPTION
Adding this code is very effective in node.
Before:
![before](https://github.com/user-attachments/assets/89c8df21-d26d-4ba8-9f1f-f66624fa863a)

After:
![after](https://github.com/user-attachments/assets/35e90a90-ec4c-49e9-9546-7d3ce7ae3f80)

Although it may seem like there is still a small increase, depending on the size of the default value of the resvg construct when freeing, I have not yet found a way to completely release the memory held by rust, but for most scenarios this increase should be negligible.