### PR TITLE
feat: add `catch_unwind` protection to `render` to prevent Node.js process crashes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,12 @@ napi-build = "2"
 [profile.release]
 lto = true    # Enable Link Time Optimization
 opt-level = 3
+# 需要确保 panic 策略是 unwind 才可以使 catch_unwind 生效，从而才能把 Rust panic 转换成错误返回给上层调用者。
+# unwind 通常是 Rust 构建的默认值，这会略微增加生成的二进制文件大小和一定的开销。
+# https://rust-lang.github.io/rfcs/1513-less-unwinding.html#compiler-defaults
+# https://doc.rust-lang.org/reference/panic.html#standard-behavior
+# 如果 panic = "abort"，panic 将立即 abort，不会展开栈，也不能被 catch_unwind 捕获。
+panic = "unwind"
 # Setting this to 1 may improve the performance of generated code, but may be slower to compile.
 # https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
 codegen-units = 1

--- a/__test__/index-panic.spec.ts
+++ b/__test__/index-panic.spec.ts
@@ -1,0 +1,63 @@
+import test from 'ava'
+
+import { Resvg } from '../index'
+
+// This test case from https://github.com/linebender/resvg/issues/1007
+test('[1]should catch panic and throw error', (t) => {
+  const svg = `<svg xmlns="http://www.w3.org/2000/svg" width="128px" height="128px" xmlns:bx="http://www.w3.org/2001/XMLSchema">
+  <defs>
+    <linearGradient id="color-2" bx:pinned="true">
+      <stop style="stop-color: #252a34;"/>
+    </linearGradient>
+    <filter id="point-light-filter-0" primitiveUnits="objectBoundingBox" x="-500%" y="-500%" width="1000%" height="1000%" bx:preset="point-light 1 0.5 0.5 0.5 50 1 0.2 0 #ffffff">
+      <feSpecularLighting result="specular-lighting" lighting-color="#ffffff" specularConstant="1" specularExponent="50">
+        <fePointLight x="0.5" y="0.5" z="0.5"/>
+      </feSpecularLighting>
+      <feDiffuseLighting result="diffuse-lighting" lighting-color="#ffffff" diffuseConstant="0.2">
+        <fePointLight x="0.5" y="0.5" z="0.5"/>
+      </feDiffuseLighting>
+      <feMerge result="lighting">
+        <feMergeNode in="diffuse-lighting"/>
+        <feMergeNode in="specular-lighting"/>
+      </feMerge>
+      <feComposite in="SourceGraphic" in2="lighting" operator="arithmetic" k1="1" k2="0" k3="0" k4="0"/>
+    </filter>
+  </defs>
+  <ellipse style="paint-order: stroke; stroke-width: 0px; fill: url(#color-2); filter: url(#point-light-filter-0);" cx="64" cy="64" rx="64" ry="64"/>
+  <g transform="matrix(3.850445, 0, 0, 3.473398, 19.614788, 19.295992)" style=""/>
+  <g transform="matrix(1, 0, 0, 1, 0.000219, -0.000004)">
+    <path d="M 69.455 32.479 Q 74 21.828 78.544 32.479 L 104.412 93.109 Q 108.956 103.76 99.867 103.76 L 48.132 103.76 Q 39.043 103.76 43.587 93.109 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(254, 254, 254);" bx:shape="triangle 39.043 21.828 69.913 81.932 0.5 0.13 1@98033a5e"/>
+    <path d="M 38.866 66.193 Q 41.653 60.58 44.44 66.193 L 60.304 98.147 Q 63.091 103.76 57.517 103.76 L 25.789 103.76 Q 20.215 103.76 23.002 98.147 Z" style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(254, 254, 254);" bx:shape="triangle 20.215 60.58 42.876 43.18 0.5 0.13 1@e89cda0c"/>
+    <ellipse style="stroke: rgb(0, 0, 0); stroke-width: 0px; fill: rgb(254, 254, 254);" cx="41.541" cy="34.856" rx="10.847" ry="10.616"/>
+  </g>
+</svg>
+  `
+  const resvg = new Resvg(svg, {
+    font: {
+      loadSystemFonts: false,
+    },
+  })
+  const error = t.throws(() => {
+    resvg.render()
+  })
+  // console.info(error)
+
+  t.true(error.message.includes('Rendering failed due to an resvg panic'))
+})
+
+// This test case from https://github.com/linebender/resvg/issues/933
+test('[2]should catch panic and throw error', (t) => {
+  const svg = `<svg version="1.0" xmlns="http://www.w3.org/2000/svg" height="32" viewBox="0 0 8.4.9" width="32" x="w"><g m=""><g><path d="m3 6h8v-158758583"/></g></g></svg>
+  `
+  const resvg = new Resvg(svg, {
+    font: {
+      loadSystemFonts: false,
+    },
+  })
+  const error = t.throws(() => {
+    resvg.render()
+  })
+  // console.info(error)
+
+  t.true(error.message.includes('Rendering failed due to an resvg panic'))
+})

--- a/src/error.rs
+++ b/src/error.rs
@@ -8,16 +8,28 @@ use thiserror::Error;
 pub enum Error {
     #[error(transparent)]
     Svg(#[from] svgtypes::Error),
+
     #[error(transparent)]
     USvg(#[from] resvg::usvg::Error),
+
     #[error(transparent)]
     Encoding(#[from] png::EncodingError),
+
     #[error(transparent)]
     Utf8(#[from] std::string::FromUtf8Error),
+
     #[error("Target size is zero (please do not set the width/height/zoom options to 0)")]
     ZeroSized,
+
+    #[error("Failed to allocate Pixmap")]
+    AllocationFailed,
+
+    #[error("Rendering failed due to an resvg panic, {0}")]
+    RenderPanic(String),
+
     #[error("Input must be string or Uint8Array")]
     InvalidInput,
+
     #[error("Unsupported image types (currently resvg only supports PNG, JPEG and GIF)")]
     UnsupportedImage,
 }

--- a/src/options.rs
+++ b/src/options.rs
@@ -214,8 +214,8 @@ impl JsOptions {
             .map(|color| color.parse::<svgtypes::Color>())
             .transpose()?;
 
-        // Unwrap is safe, because `size` is already valid.
-        let mut pixmap = Pixmap::new(width, height).unwrap();
+        // Unwrap is not safe, we must check for allocation failure
+        let mut pixmap = Pixmap::new(width, height).ok_or(Error::AllocationFailed)?;
 
         if let Some(bg) = background {
             let color = resvg::tiny_skia::Color::from_rgba8(bg.red, bg.green, bg.blue, bg.alpha);


### PR DESCRIPTION
## Background

When the upstream [resvg](https://github.com/linebender/resvg/issues?q=is%3Aissue%20state%3Aopen%20panic) (Rust) encounters an SVG that cannot be rendered, it may panic. This causes the **Node.js process to crash** immediately, resulting in a core dump.

## ✅ Node.js
- Use `catch_unwind` in the resvg-js Rust layer to capture panics, converting them into explicit errors to prevent direct panics from crashing the Node.js process.
https://doc.rust-lang.org/book/ch09-01-unrecoverable-errors-with-panic.html
- Remove `unwrap()` at critical points in the resvg-js rendering pipeline.

There are also some upstream PRs working towards this goal, but they haven't been merged yet:
- https://github.com/linebender/resvg/pull/926
- https://github.com/linebender/resvg/pull/472

## 🚧 Wasm
By default the `wasm32-unknown-unknown` target is compiled with `-Cpanic=abort`. Historically this was due to the fact that there was no way to catch panics in wasm, but since mid-2025 the WebAssembly [exception-handling proposal](https://github.com/WebAssembly/exception-handling) reached stabilization. LLVM has support for this proposal as well and when this is all combined together it's possible to enable `-Cpanic=unwind` on wasm targets. 
See https://doc.rust-lang.org/rustc/platform-support/wasm32-unknown-unknown.html#unwinding

However, considering that this would increase the size of the `wasm` file and require runtime support, we will not enable it at this time.

- 【Wasmtime】https://cfallin.org/blog/2025/11/06/exceptions/
- https://webassembly.org/features/
- https://github.com/WebAssembly/exception-handling
- https://rajrajhans.com/2023/07/handling-rust-panics-in-wasm/
